### PR TITLE
Fix typo in ReplaceBadWordsTest.php

### DIFF
--- a/test/Model/Service/ReplaceBadWordsTest.php
+++ b/test/Model/Service/ReplaceBadWordsTest.php
@@ -9,8 +9,8 @@ use PHPUnit\Framework\TestCase;
  *
  * The following code contains extremely explicit language.
  *
- * We have written code this code to prevent users from publicly posting
- * foul, vulgar, and offesnive language.
+ * We have written code to prevent users from publicly posting foul, vulgar,
+ * and offensive language.
  *
  * In order to ensure that this code is functioning properly,
  * we must use explicit language in our own code.


### PR DESCRIPTION
Found and fixed a typo in one of the tests:

`offesnive => offensive`

Also slightly changed the wording to match similar sentences in other files:

`We have written code this code to ... => We habe written code to ...`